### PR TITLE
feat(puppeteer): support new headless mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,8 @@ var _default = {
               }
 
               launchArgs = {
-                timeout: 10000
+                timeout: 10000,
+                headless: 'new'
               };
               noSandboxArgs = ['--no-sandbox', '--disable-setuid-sandbox'];
               if (browserArgs.indexOf('no_sandbox') !== -1) launchArgs.args = noSandboxArgs;else if (browserName.indexOf('?') !== -1) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "testcafe-browser-provider-puppeteer-launcher",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "testcafe-browser-provider-puppeteer-launcher",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-browser-provider-puppeteer-launcher",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Yet another puppeteer TestCafe browser provider plugin.",
   "repository": "https://github.com/elmy-team/testcafe-browser-provider-puppeteer-launcher",
   "homepage": "https://github.com/elmy-team/testcafe-browser-provider-puppeteer-launcher",

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ export default {
     if (!this.browser) {
       const launchArgs = {
         timeout: 10000,
+        headless: 'new',
       };
 
       const noSandboxArgs = ['--no-sandbox', '--disable-setuid-sandbox'];


### PR DESCRIPTION
```
  Puppeteer old Headless deprecation warning:
    In the near future `headless: true` will default to the new Headless mode
    for Chrome instead of the old Headless implementation. For more
    information, please see https://developer.chrome.com/articles/new-headless/.
    Consider opting in early by passing `headless: "new"` to `puppeteer.launch()`
    If you encounter any bugs, please report them to https://github.com/puppeteer/puppeteer/issues/new/choose.
```